### PR TITLE
[fix] fixed libfbjni.so crash when Instance is destoryed

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -392,15 +392,17 @@ public class CatalystInstanceImpl implements CatalystInstance {
                                           public void run() {
                                             // Kill non-UI threads from neutral third party
                                             // potentially expensive, so don't run on UI thread
+                                            
+                                            // fixed libfbjni.so crash when Instance is destroyed
+                                            getReactQueueConfiguration().destroy();
 
                                             // contextHolder is used as a lock to guard against
                                             // other users of the JS VM having the VM destroyed
                                             // underneath them, so notify them before we reset
-                                            // Native
+                                            // Native                                            
                                             mJavaScriptContextHolder.clear();
-
                                             mHybridData.resetNative();
-                                            getReactQueueConfiguration().destroy();
+                                            
                                             FLog.d(
                                                 ReactConstants.TAG,
                                                 "CatalystInstanceImpl.destroy() end");


### PR DESCRIPTION
signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x1e
Abort message: JNI DETECTED ERROR IN APPLICATION: obj == null     in call to CallVoidMethodV     from void com.facebook.react.bridge.queue.NativeRunnable.run()
backtrace:
#00 pc 00074d16  /data/app/~~xUAbgqHDYDxI0Fyr-DyU-g==/ctrip.android.view-XyP16_0Ztoi7aU_Iz9xsEg==/lib/arm/libfbjni.so
#01 pc 00074917  /data/app/~~xUAbgqHDYDxI0Fyr-DyU-g==/ctrip.android.view-XyP16_0Ztoi7aU_Iz9xsEg==/lib/arm/libfbjni.so
#02 pc 000719c9  /data/app/~~xUAbgqHDYDxI0Fyr-DyU-g==/ctrip.android.view-XyP16_0Ztoi7aU_Iz9xsEg==/lib/arm/libfbjni.so
